### PR TITLE
Update README, change license to BSD-3-Clause

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "poco-scheme"
 description = "A toy Scheme implementation"
 version = "0.0.1"
 authors = ["Andreas Rottmann <mail@r0tty.org>"]
-license = "MIT OR Apache-2.0"
+license = "BSD-3-Clause"
 repository = "https://github.com/rotty/poco-scheme"
 edition = "2018"
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2019 Andreas Rottmann
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+  3. Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,30 @@
-# A toy Scheme interpreter
+# An implementation of a tiny Scheme subset
 
 This is an implementation of a (currently miniscule) subset of
-R7RS-small. See [the examples directory](./scheme-examples) for a
-glimpse of what already works.
+R7RS-small. See [the examples directory](./scheme-examples) and the
+[smoke tests](./tests/scheme/smoke.scm)for to get an idea of what
+already works.
+
+The architecture is currently a fairly basic interpreter, with syntax
+analysis phase up-front, which will transform the raw S-expressions
+into an AST, which is then evaluated. This code sprang from code
+intended as an example for using the [`lexpr`] crate to implement a
+simple S-expression calculator, and got a bit out of hand 😀.
+
+The current architecture is insufficient to support several major
+language features of Scheme, such as macros or continuations. The plan
+is to gradually improve the implementation to make such features
+possible, before investing in additional features based on the current
+architecture.
+
+The evolution of poco-scheme will probably be largely guided by the
+[chibi-scheme] codebase. chibi-scheme is a full implementation of
+R7RS-small, written in C, employing a bytecode VM, and using syntactic
+closures as the basic macro mechanism.
 
 ## Features already present
 
 - Proper tail calls.
-- Simple transformation from raw S-expressions to an AST; the
-  interpreter works on the latter.
 - Garbage collection employing the `gc` crate.
 - `define`, `lambda`, `if`.
 - Fixnums, and some procedures working on numbers.
@@ -20,3 +36,6 @@ glimpse of what already works.
 - Implement more syntax in `lexpr`:
   - Quote syntactic shorthand (i.e. `'`).
 - Add a transformation of the AST to some kind of bytecode.
+
+[chibi-scheme]: http://synthcode.com/wiki/chibi-scheme
+[`lexpr`]: https://crates.io/crates/lexpr

--- a/tests/scheme/smoke.scm
+++ b/tests/scheme/smoke.scm
@@ -50,9 +50,11 @@
          (define (prime? n)
            (define bound (sqrt n))
            (define (loop divisor)
-             (if (= 0 (modulo n divisor))
-                 #f
-                 (loop (+ divisor 2))))
+             (if (> divisor bound)
+                 #t
+                 (if (= 0 (modulo n divisor))
+                     #f
+                     (loop (+ divisor 2)))))
            (loop 3))
          (prime? 42))
        => #f)


### PR DESCRIPTION
Re-licensed to BSD-3-Clause, text as found on
<https://spdx.org/licenses/BSD-3-Clause.html>. This is in expectation
of borrowing a lot of ideas from chibi-scheme, which is also licensed
under a 3-clause BSD license.

A note for the legally-minded: The license text of chibi-scheme is not
100% identical, but the difference is basically just a rewording of
"author" (chibi-scheme) to "copyright holder or contributor" (SPDX
license text). Also note that at least up to and including this
commit, the poco-scheme codebase is not derived of chibi-scheme in any
way.